### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-run-and-push.yml
+++ b/.github/workflows/python-run-and-push.yml
@@ -1,6 +1,10 @@
 # Workflow name
 name: Run Python Script and Push Changes
 
+# Define permissions for the workflow
+permissions:
+  contents: write
+
 # Define triggers for the workflow
 on:
   # Scheduled to run daily at midnight UTC


### PR DESCRIPTION
Potential fix for [https://github.com/Strong-Foundation/fmc-com-documentation/security/code-scanning/1](https://github.com/Strong-Foundation/fmc-com-documentation/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow involves pushing changes to the repository, it requires `contents: write` permissions. However, no other permissions are needed, so we should explicitly limit the permissions to `contents: write`. This can be done at the workflow level (applied to all jobs) or at the job level (specific to the `build` job). In this case, we will add the `permissions` block at the workflow level for simplicity and clarity.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
